### PR TITLE
Ajusta .gitignore para não incluir .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 DS_Store
 node_modules
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .idea
-DS_Store
 node_modules
 .DS_Store


### PR DESCRIPTION
No .gitignore original o DS_Store estava sem o ponto inicial e por isso os arquivos não estavam sendo ignorados.